### PR TITLE
Experiment/add more languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ Features:
 - Spanish - Español
 - Arabic - العربية
 - German - Deutsch
+- Hindi - हिन्दी, हिंदी
+- Bengali - বাংলা
+- Indonesian - Bahasa Indonesia
+- French - français
+- Russian - русский
+- Portuguese - Português
+- Japanese - 日本語 (にほんご)
+- Italian - Italiano
+- Greek - Ελληνικά
+- Korean - 한국어
+- Swahili - Kiswahili
 
 </details>
 

--- a/lib/core/providers/favourites_state.dart
+++ b/lib/core/providers/favourites_state.dart
@@ -8,6 +8,8 @@ class FavouritesState extends ChangeNotifier {
   List<Station> _favourites = [];
   List<Station> get favourites => _favourites;
 
+  bool get isLoading => _stationsCollectionService.isLoading; 
+
   FavouritesState() {
     _init();
   }

--- a/lib/core/providers/stations_state.dart
+++ b/lib/core/providers/stations_state.dart
@@ -8,6 +8,7 @@ class StationsState extends ChangeNotifier {
   static const int limit = 10;
 
   bool isUpdating = false;
+  bool isLoading = false;
 
   // station collections
   static List<StationsCollectionService> _collections = StationsCollectionsService.collections;
@@ -20,7 +21,10 @@ class StationsState extends ChangeNotifier {
   }
 
   void _init() async {
+    isLoading = true;
+    notifyListeners();
     _collections = await StationsCollectionsService.populateCollections();
+    isLoading = false;
     notifyListeners();
   }
 

--- a/lib/services/stations_collection_service.dart
+++ b/lib/services/stations_collection_service.dart
@@ -17,8 +17,10 @@ class StationsCollectionService {
   }
 
   final String title;
-  List<Station> collection = [];
   final bool isFavouritesList;
+
+  List<Station> collection = [];
+  bool isLoading = false;
 
   StationsFilter filter = kDefaultStationsFilter;
 
@@ -39,15 +41,24 @@ class StationsCollectionService {
       return await StationsService.getStreamsByStationUUID(favouritesList,
           isFavourite: isFavouritesList);
     }
+
     return await StationsService.getStreams(filter,
         favouritesList: favouritesList, blacklist: blacklist);
   }
 
   Future<List<Station>> refreshStations({bool isUpdate = false}) async {
+    List<Station> _stations;
     if (isUpdate) {
-      return await _getMoreStations();
+        isLoading = true;
+        _stations = await _getMoreStations();
+        debugPrint(_stations.length.toString());
+        isLoading = false;
+        return _stations;
     }
-    return await _fetchStations();
+    isLoading = true;
+    _stations = await _fetchStations();
+    isLoading = false;
+    return _stations;
   }
 
   static void _removeStationByUUID(
@@ -75,6 +86,7 @@ class StationsCollectionService {
     int newOffset = filter.offset + filter.limit;
 
     Map<String, dynamic> filterMap = filter.toMap();
+
 
     filterMap['offset'] = newOffset;
 

--- a/lib/services/stations_collection_service.dart
+++ b/lib/services/stations_collection_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:lingo_jam/core/constants/constants.dart';
 import 'package:lingo_jam/model/station/station.dart';
 import 'package:lingo_jam/model/station/stations_filter.dart';
@@ -18,6 +19,7 @@ class StationsCollectionService {
 
   final String title;
   final bool isFavouritesList;
+  bool moreStationsAreAvailable = true;
 
   List<Station> collection = [];
   bool isLoading = false;
@@ -49,11 +51,13 @@ class StationsCollectionService {
   Future<List<Station>> refreshStations({bool isUpdate = false}) async {
     List<Station> _stations;
     if (isUpdate) {
+      if (moreStationsAreAvailable) {
         isLoading = true;
         _stations = await _getMoreStations();
         debugPrint(_stations.length.toString());
         isLoading = false;
         return _stations;
+      }
     }
     isLoading = true;
     _stations = await _fetchStations();
@@ -84,7 +88,6 @@ class StationsCollectionService {
     /// ok for now.
 
     int newOffset = filter.offset + filter.limit;
-
     Map<String, dynamic> filterMap = filter.toMap();
 
 
@@ -93,6 +96,14 @@ class StationsCollectionService {
     filter = StationsFilter.fromMap(filterMap);
 
     List<Station> newStations = await _fetchStations();
+
+    if (newStations.isEmpty) {
+      moreStationsAreAvailable = false;
+      debugPrint(
+          'StationsCollectionService::_getMoreStations. No More stations available. Not fetching anything new.');
+      return collection;      
+    }
+
 
     for (Station newStation in newStations) {
       // don't add duplicates

--- a/lib/services/stations_collections_service.dart
+++ b/lib/services/stations_collections_service.dart
@@ -9,7 +9,7 @@ import 'package:lingo_jam/services/locale_service.dart';
 
 class StationsCollectionsService {
 
-  static final List<String> _defaultLanguages = ['chinese', 'english', 'spanish', 'german', 'arabic'];
+  static final List<String> _defaultLanguages = ['chinese', 'english', 'spanish', 'german', 'arabic', 'hindi', 'bengali', 'indonesian', 'french', 'russian', 'portuguese'];
   static final List<StationsCollectionService> _collections = [];
 
   static final LocaleService _localeService = LocaleService();
@@ -29,7 +29,12 @@ class StationsCollectionsService {
         order: Order.clickCount, 
         reverse: true
       );
-      var stationCollection = StationsCollectionService(title: 'Stations in ${languageISOCode.endonym}', filter: filter);
+
+      String title = languageISOCode.endonym;
+
+      if(languageISOCode.endonym.toLowerCase() != 'english') title += ' (${languageISOCode.name})';
+
+      var stationCollection = StationsCollectionService(title: title, filter: filter);
 
       await stationCollection.stations;
       _collections.add(stationCollection);

--- a/lib/services/stations_collections_service.dart
+++ b/lib/services/stations_collections_service.dart
@@ -19,7 +19,12 @@ class StationsCollectionsService {
     'indonesian',
     'french',
     'russian',
-    'portuguese'
+    'portuguese',
+    'japanese',
+    'italian',
+    'greek',
+    'korean',
+    'swahili'
   ];
   static final List<StationsCollectionService> _collections = [];
 

--- a/lib/services/stations_collections_service.dart
+++ b/lib/services/stations_collections_service.dart
@@ -8,33 +8,50 @@ import 'package:lingo_jam/services/locale_service.dart';
 // get languages when the app starts up (before you want to access the list in the home screen) possibly in state init
 
 class StationsCollectionsService {
-
-  static final List<String> _defaultLanguages = ['chinese', 'english', 'spanish', 'german', 'arabic', 'hindi', 'bengali', 'indonesian', 'french', 'russian', 'portuguese'];
+  static final List<String> _defaultLanguages = [
+    'chinese',
+    'english',
+    'spanish',
+    'german',
+    'arabic',
+    'hindi',
+    'bengali',
+    'indonesian',
+    'french',
+    'russian',
+    'portuguese'
+  ];
   static final List<StationsCollectionService> _collections = [];
 
   static final LocaleService _localeService = LocaleService();
 
   static List<StationsCollectionService> get collections => _collections;
-  static StationsCollectionService collection(String stationTitle) => _getStationCollectionByTitle(stationTitle);
+  static StationsCollectionService collection(String stationTitle) =>
+      _getStationCollectionByTitle(stationTitle);
 
-  static StationsCollectionService _getStationCollectionByTitle(String stationTitle) {
-    return _collections.firstWhere((collection) => collection.title == stationTitle);
+  static StationsCollectionService _getStationCollectionByTitle(
+      String stationTitle) {
+    return _collections
+        .firstWhere((collection) => collection.title == stationTitle);
   }
 
   static Future<List<StationsCollectionService>> populateCollections() async {
-    for(var language in _defaultLanguages) {
-      var languageISOCode = await _localeService.getISOLocaleByLanguageName(language);
-      var filter = StationsFilter( 
-        language: languageISOCode.name.toLowerCase(), 
-        order: Order.clickCount, 
-        reverse: true
-      );
+    for (var language in _defaultLanguages) {
+      var languageISOCode =
+          await _localeService.getISOLocaleByLanguageName(language);
+      var filter = StationsFilter(
+          language: languageISOCode.name.toLowerCase(),
+          order: Order.clickCount,
+          reverse: true);
 
       String title = languageISOCode.endonym;
 
-      if(languageISOCode.endonym.toLowerCase() != 'english') title += ' (${languageISOCode.name})';
+      if (languageISOCode.endonym.toLowerCase() != 'english') {
+        title += ' (${languageISOCode.name})';
+      }
 
-      var stationCollection = StationsCollectionService(title: title, filter: filter);
+      var stationCollection =
+          StationsCollectionService(title: title, filter: filter);
 
       await stationCollection.stations;
       _collections.add(stationCollection);

--- a/lib/ui/favourites/favourites_view.dart
+++ b/lib/ui/favourites/favourites_view.dart
@@ -12,12 +12,36 @@ class FavouritesView extends StatelessWidget {
     return Consumer<FavouritesState>(
       builder: (BuildContext context, FavouritesState state, Widget? child) {
         List<Station> favourites = state.favourites;
+        if (favourites.isEmpty) {
+          return Column(
+            children: [
+              Padding(
+                padding:
+                    const EdgeInsets.only(left: 8.0, top: 8.0, bottom: 8.0),
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: Text(
+                    'Favourites',
+                    style: TextStyle(
+                      fontSize: 16 * MediaQuery.of(context).textScaleFactor,
+                    ),
+                  ),
+                ),
+              ),
+              const Expanded(
+                child: Center(
+                  child: Text('You haven\'t favourited anything yet. 🥺'),
+                ),
+              ),
+            ],
+          );
+        }
         return StationsCollection(
-            stations: favourites,
+          stations: favourites,
           isLoading: state.isLoading,
-            title: "Favourites",
-            scrollDirection: Axis.vertical,
-            );
+          title: "Favourites",
+          scrollDirection: Axis.vertical,
+        );
       },
     );
   }

--- a/lib/ui/favourites/favourites_view.dart
+++ b/lib/ui/favourites/favourites_view.dart
@@ -14,6 +14,7 @@ class FavouritesView extends StatelessWidget {
         List<Station> favourites = state.favourites;
         return StationsCollection(
             stations: favourites,
+          isLoading: state.isLoading,
             title: "Favourites",
             scrollDirection: Axis.vertical,
             );

--- a/lib/ui/station/stations_collection.dart
+++ b/lib/ui/station/stations_collection.dart
@@ -14,6 +14,7 @@ class StationsCollection extends StatelessWidget {
     this.scrollDirection = Axis.horizontal,
     this.fetchMoreStationsCallback,
     required this.isLoading,
+    this.moreStationsAreAvailable = false,
   }) : super(key: key);
 
   final List<Station> stations;
@@ -21,6 +22,7 @@ class StationsCollection extends StatelessWidget {
   final Axis scrollDirection;
   final Future Function()? fetchMoreStationsCallback;
   final bool isLoading;
+  final bool moreStationsAreAvailable;
 
   @override
   Widget build(BuildContext context) {
@@ -93,7 +95,7 @@ class StationsCollection extends StatelessWidget {
       int lastIndex = itemPositionsListener.itemPositions.value.last.index;
       bool shouldFetchMoreStations = stations.length - (lastIndex + 1) < 2;
 
-      if (shouldFetchMoreStations) {
+      if (shouldFetchMoreStations && moreStationsAreAvailable) {
         debugPrint('fetching more stations. lastIndex: $lastIndex');
         await fetchMoreStationsCallback!();
       }

--- a/lib/ui/station/stations_collection.dart
+++ b/lib/ui/station/stations_collection.dart
@@ -13,12 +13,14 @@ class StationsCollection extends StatelessWidget {
     required this.title,
     this.scrollDirection = Axis.horizontal,
     this.fetchMoreStationsCallback,
+    required this.isLoading,
   }) : super(key: key);
 
   final List<Station> stations;
   final String title;
   final Axis scrollDirection;
   final Future Function()? fetchMoreStationsCallback;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -73,7 +75,9 @@ class StationsCollection extends StatelessWidget {
           placeholderImagePath: station.placeholderFavicon,
           title: station.name,
           onTap: () {
-            context.read<AppState>().playStream(newStation: station, collection: stations);
+            context
+                .read<AppState>()
+                .playStream(newStation: station, collection: stations);
           },
           imageUrl: station.favicon,
         );
@@ -87,8 +91,9 @@ class StationsCollection extends StatelessWidget {
 
     itemPositionsListener.itemPositions.addListener(() async {
       int lastIndex = itemPositionsListener.itemPositions.value.last.index;
-      bool shouldFetchMoreStations = stations.length - (lastIndex + 1) < 5;
-      if(shouldFetchMoreStations) {
+      bool shouldFetchMoreStations = stations.length - (lastIndex + 1) < 2;
+
+      if (shouldFetchMoreStations) {
         debugPrint('fetching more stations. lastIndex: $lastIndex');
         await fetchMoreStationsCallback!();
       }
@@ -96,9 +101,21 @@ class StationsCollection extends StatelessWidget {
 
     return ScrollablePositionedList.builder(
       scrollDirection: scrollDirection,
-      itemCount: stations.length,
+      itemCount: stations.length + 1,
       itemBuilder: (BuildContext context, int index) {
+        if (index == stations.length) {
+          return isLoading
+              ? const SizedBox(
+                  height: 200,
+                  width: 200,
+                  child: Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                )
+              : const SizedBox();
+        }
         Station station = stations[index];
+        // return Text('placeholder');
         return Tile(
           maxWidth: 180,
           enableCustomBackground: true,
@@ -106,7 +123,9 @@ class StationsCollection extends StatelessWidget {
           placeholderImagePath: station.placeholderFavicon,
           title: station.name,
           onTap: () {
-            context.read<AppState>().playStream(newStation: station, collection: stations);
+            context
+                .read<AppState>()
+                .playStream(newStation: station, collection: stations);
           },
           imageUrl: station.favicon,
         );

--- a/lib/ui/station/stations_collections.dart
+++ b/lib/ui/station/stations_collections.dart
@@ -20,11 +20,12 @@ class StationsCollections extends StatelessWidget {
             services_sc.StationsCollectionService currentStation =
                 state.stations[i];
             return StationsCollection(
-              fetchMoreStationsCallback: () => state.updateStreamList(i),
-              title: currentStation.title,
-              stations: currentStation.collection,
-              isLoading: currentStation.isLoading,
-            );
+                fetchMoreStationsCallback: () => state.updateStreamList(i),
+                title: currentStation.title,
+                stations: currentStation.collection,
+                isLoading: currentStation.isLoading,
+                moreStationsAreAvailable:
+                    currentStation.moreStationsAreAvailable);
           },
         );
         if (state.isLoading) {

--- a/lib/ui/station/stations_collections.dart
+++ b/lib/ui/station/stations_collections.dart
@@ -12,19 +12,25 @@ class StationsCollections extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<StationsState>(
       builder: (BuildContext context, StationsState state, Widget? child) {
-        return ListView.builder(
+        Widget _child = ListView.builder(
           itemCount: state.stations.length,
           shrinkWrap: true,
           scrollDirection: Axis.vertical,
           itemBuilder: (BuildContext context, int i) {
-            services_sc.StationsCollectionService currentStation = state.stations[i];
+            services_sc.StationsCollectionService currentStation =
+                state.stations[i];
             return StationsCollection(
               fetchMoreStationsCallback: () => state.updateStreamList(i),
               title: currentStation.title,
               stations: currentStation.collection,
+              isLoading: currentStation.isLoading,
             );
           },
         );
+        if (state.isLoading) {
+          _child = const Center(child: CircularProgressIndicator());
+        }
+        return _child;
       },
     );
   }


### PR DESCRIPTION
Adds more languages to the list. See updated README for the list.

Bonus:
- Spinners will now show when stations are loading on the home screen and when new stations are being fetched to let the user know something is, indeed, happening.
- When there are no more stations to be fetched, the app will no longer attempt to fetch stations for that particular collection.
- A message + sad emoji is shown for users who navigate to the favourites page but have not yet favourited anything.